### PR TITLE
Fixed: iOS Version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -140,8 +140,7 @@ const GetClientInfo = (req) => {
                 osVersion = /Android ([\.\_\d]+)/.exec(nAgt)[1];
                 break;
             case 'iOS':
-                const osVersionArr = /OS (\d+)_(\d+)_?(\d+)?/.exec(nVer);
-                osVersion = `${osVersionArr[1]}.${osVersionArr[2]}.${osVersionArr[3]}`;
+                osVersion = /OS ([\.\_\d]+)/.exec(nAgt)[1];
                 break;
         }
         const detectInfo = {

--- a/index.ts
+++ b/index.ts
@@ -159,8 +159,7 @@ export const GetClientInfo = (req: any): DetectReqOut => {
         break;
 
       case 'iOS':
-        const osVersionArr = /OS (\d+)_(\d+)_?(\d+)?/.exec(nVer);
-        osVersion = `${osVersionArr[1]}.${osVersionArr[2]}.${osVersionArr[3]}`;
+        osVersion = /OS ([\.\_\d]+)/.exec(nAgt)[1];
         break;
     }
 


### PR DESCRIPTION
문제 : iOS일 경우 TypeError: Cannot read property '1' of null 에러발생

원인: nVer이 undefined일 경우 해당 문제 발생

해결 : iOS 일 경우에도 Android & Mac OS 와 동일하게 osVersion 할당